### PR TITLE
Update repo address for reporting issues

### DIFF
--- a/ETA/ETA.js
+++ b/ETA/ETA.js
@@ -3,7 +3,7 @@
 // @namespace	http://tampermonkey.net/
 // @version		0.3.11-0.19.1
 // @description	Shows xp/h and mastery xp/h, and the time remaining until certain targets are reached. Takes into account Mastery Levels and other bonuses.
-// @description	Please report issues on https://github.com/gmiclotte/Melvor-Time-Remaining/issues or message TinyCoyote#1769 on Discord
+// @description	Please report issues on https://github.com/gmiclotte/melvor-scripts/issues or message TinyCoyote#1769 on Discord
 // @description	The last part of the version number is the most recent version of Melvor that was tested with this script. More recent versions might break the script.
 // @description	Forked from Breindahl#2660's Melvor TimeRemaining script v0.6.2.2., originally developed by Breindahl#2660, Xhaf#6478 and Visua#9999
 // @author		GMiclotte


### PR DESCRIPTION
Noticed the github address for reporting issues points at the deprecated Melvor-Time-Remaining repo. Updated to point at melvor-scripts instead.